### PR TITLE
Fixes bug when `initialize_connection()` doesn't pass parameters to spark initialization routine.

### DIFF
--- a/R/connection.R
+++ b/R/connection.R
@@ -190,9 +190,9 @@ initialize_connection <- function(sc) {
   conf <- invoke(conf, "setAppName", sc$app_name)
   conf <- invoke(conf, "setMaster", sc$master)
   conf <- invoke(conf, "setSparkHome", sc$spark_home)
-  context_config <- connection_config(sc, "spark.context.")
+  context_config <- connection_config(sc, "spark.")
   lapply(names(context_config), function(param) {
-    conf <<- invoke(conf, "set", param, context_config[[param]])
+    conf <<- invoke(conf, "set", paste0("spark.", param), context_config[[param]])
   })
 
   # create the spark context and assign the connection to it


### PR DESCRIPTION
Consider following simple example:
```r

conf = list("sparklyr.shell.driver-memory" = "4g", 
            "spark.yarn.executor.memoryOverhead" = "1000", 
            "spark.executor.instances" = "8", 
            "spark.executor.cores" = "4", 
            "spark.sql.shuffle.partitions" = "256")
scon <- sparkapi::start_shell(master = 'yarn-client', config = conf)
# or
# sc <- sparklyr::spark_connect(master = "yarn-client", config = conf)
```
According to [docs](http://spark.rstudio.com/deployment.html#spark_options) This should initialise YARN job with parameters listed above. However it starts shell with default parameters (because it try to match for `spark.context.*` and also cuts prefix...):
<img width="927" alt="screen shot 2016-07-08 at 13 39 20" src="https://cloud.githubusercontent.com/assets/5123805/16685109/7aec0654-4511-11e6-8685-f964457252a4.png">
<img width="1036" alt="screen shot 2016-07-08 at 13 40 23" src="https://cloud.githubusercontent.com/assets/5123805/16685124/92411be6-4511-11e6-9366-c897501f7a8a.png">

This pull request fixes such incorrect behaviour.