### PR TITLE
add support for optional versions in sparkapi

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparkapi
 Type: Package
 Title: Spark API Interface
-Version: 0.3.18
+Version: 0.3.19
 Authors@R: c(
   person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
   person(family = "The Apache Software Foundation", role = c("aut", "cph")),

--- a/R/connection.R
+++ b/R/connection.R
@@ -105,6 +105,17 @@ spark_version <- function(sc) {
   numeric_version(version)
 }
 
+spark_version_from_home_version <- function() {
+  version <- Sys.getenv("SPARK_HOME_VERSION")
+  if (is.null(version)) {
+    stop(
+      "RELEASE file not found and the SPARK_HOME_VERSION ",
+      "environment variable is not set.")
+  }
+
+  numeric_version(version)
+}
+
 #' Version of Spark for a SPARK_HOME directory
 #'
 #' @param spark_home Path to SPARK_HOME
@@ -114,14 +125,25 @@ spark_version <- function(sc) {
 #' @export
 spark_version_from_home <- function(spark_home) {
   releaseFile <- file.path(spark_home, "RELEASE")
+
+  if (!file.exists(releaseFile)) {
+    return(spark_version_from_home_version())
+  }
+
   releaseContents <- readLines(releaseFile)
-  version <- gsub("Spark | built.*", "", releaseContents[[1]])
 
-  # Get rid of -preview and other suffix variations
-  version <- spark_version_clean(version)
+  if (is.null(releaseContents) || length(releaseContents) == 0) {
+    spark_version_from_home_version()
+  }
+  else {
+    version <- gsub("Spark | built.*", "", releaseContents[[1]])
 
-  # return numeric version
-  numeric_version(version)
+    # Get rid of -preview and other suffix variations
+    version <- spark_version_clean(version)
+
+    # return numeric version
+    numeric_version(version)
+  }
 }
 
 #' Read configuration values for a connection

--- a/R/connection.R
+++ b/R/connection.R
@@ -107,13 +107,7 @@ spark_version <- function(sc) {
 
 spark_version_from_home_version <- function() {
   version <- Sys.getenv("SPARK_HOME_VERSION")
-  if (is.null(version)) {
-    stop(
-      "RELEASE file not found and the SPARK_HOME_VERSION ",
-      "environment variable is not set.")
-  }
-
-  numeric_version(version)
+  if (nchar(version) <= 0) NULL else version
 }
 
 #' Version of Spark for a SPARK_HOME directory
@@ -124,26 +118,58 @@ spark_version_from_home_version <- function() {
 #'
 #' @export
 spark_version_from_home <- function(spark_home) {
-  releaseFile <- file.path(spark_home, "RELEASE")
+  versionAttempts <- list(
+    useReleaseFile = function() {
+      versionedFile <- file.path(spark_home, "RELEASE")
+      if (file.exists(versionedFile)) {
+        releaseContents <- readLines(versionedFile)
 
-  if (!file.exists(releaseFile)) {
-    return(spark_version_from_home_version())
+        if (!is.null(releaseContents) && length(releaseContents) > 0) {
+          gsub("Spark | built.*", "", releaseContents[[1]])
+        }
+      }
+    },
+    useAssemblies = function() {
+      candidateVersions <- list(
+        list(path = "lib", pattern = "spark-assembly-([0-9\\.]*)-hadoop.[0-9\\.]*\\.jar"),
+        list(path = "yarn", pattern = "spark-([0-9\\.]*)-preview-yarn-shuffle\\.jar")
+      )
+
+      candidateFiles <- lapply(candidateVersions, function(e) {
+        c(e,
+          list(
+            files = list.files(
+              file.path(spark_home, e$path),
+              pattern = e$pattern
+            )
+          )
+        )
+      })
+
+      filteredCandidates <- Filter(function(f) length(f$files) > 0, candidateFiles)
+      if (length(filteredCandidates) > 0) {
+        valid <- filteredCandidates[[1]]
+        e <- regexec(valid$pattern, valid$files[[1]])
+        match <- regmatches(valid$files[[1]], e)
+        if (length(match) > 0 && length(match[[1]]) > 1) {
+          return(match[[1]][[2]])
+        }
+      }
+    },
+    useEnvironmentVariable = function() {
+      spark_version_from_home_version()
+    }
+  )
+
+  for (versionAttempt in versionAttempts) {
+    result <- versionAttempt()
+    if (length(result) > 0)
+      return(spark_version_clean(result))
   }
 
-  releaseContents <- readLines(releaseFile)
-
-  if (is.null(releaseContents) || length(releaseContents) == 0) {
-    spark_version_from_home_version()
-  }
-  else {
-    version <- gsub("Spark | built.*", "", releaseContents[[1]])
-
-    # Get rid of -preview and other suffix variations
-    version <- spark_version_clean(version)
-
-    # return numeric version
-    numeric_version(version)
-  }
+  stop(
+    "Failed to detect version from SPARK_HOME or SPARK_HOME_VERSION. ",
+    "Try passing the spark_version explicitly.")
 }
 
 #' Read configuration values for a connection

--- a/R/shell.R
+++ b/R/shell.R
@@ -3,6 +3,8 @@
 #' @param master Spark cluster url to connect to. Use \code{"local"} to connect to a local
 #'   instance of Spark
 #' @param spark_home Spark home directory (defaults to SPARK_HOME environment variable)
+#' @param spark_version Spark version, if not specified, version taken from SPARK_HOME
+#' @param hadoop_version Hadoop version, if not specified, version taken from SPARK_HOME
 #' @param app_name Application name to be used while running in the Spark cluster
 #' @param config Named character vector of spark.* options
 #' @param jars Paths to Jar files to include
@@ -18,6 +20,8 @@
 #' @export
 start_shell <- function(master,
                         spark_home = Sys.getenv("SPARK_HOME"),
+                        spark_version = NULL,
+                        hadoop_version = NULL,
                         app_name = "sparkapi",
                         config = list(),
                         extensions = sparkapi::registered_extensions(),
@@ -57,7 +61,12 @@ start_shell <- function(master,
   spark_submit_path <- normalizePath(file.path(spark_home, "bin", spark_submit))
 
   # resolve extensions
-  spark_version <- spark_version_from_home(spark_home)
+  spark_version <- numeric_version(
+    ifelse(is.null(spark_version),
+      spark_version_from_home(spark_home),
+      gsub("[-_a-zA-Z]", "", spark_version)
+    )
+  )
   scala_version <- numeric_version("2.10")
   extensions <- spark_dependencies_from_extensions(spark_version, scala_version, extensions)
 

--- a/R/shell.R
+++ b/R/shell.R
@@ -4,7 +4,6 @@
 #'   instance of Spark
 #' @param spark_home Spark home directory (defaults to SPARK_HOME environment variable)
 #' @param spark_version Spark version, if not specified, version taken from SPARK_HOME
-#' @param hadoop_version Hadoop version, if not specified, version taken from SPARK_HOME
 #' @param app_name Application name to be used while running in the Spark cluster
 #' @param config Named character vector of spark.* options
 #' @param jars Paths to Jar files to include
@@ -21,7 +20,6 @@
 start_shell <- function(master,
                         spark_home = Sys.getenv("SPARK_HOME"),
                         spark_version = NULL,
-                        hadoop_version = NULL,
                         app_name = "sparkapi",
                         config = list(),
                         extensions = sparkapi::registered_extensions(),

--- a/man/start_shell.Rd
+++ b/man/start_shell.Rd
@@ -6,9 +6,9 @@
 \title{Start the Spark R Shell}
 \usage{
 start_shell(master, spark_home = Sys.getenv("SPARK_HOME"),
-  app_name = "sparkapi", config = list(),
-  extensions = sparkapi::registered_extensions(), jars = NULL,
-  packages = NULL, environment = NULL, shell_args = NULL)
+  spark_version = NULL, hadoop_version = NULL, app_name = "sparkapi",
+  config = list(), extensions = sparkapi::registered_extensions(),
+  jars = NULL, packages = NULL, environment = NULL, shell_args = NULL)
 
 stop_shell(sc)
 }
@@ -17,6 +17,10 @@ stop_shell(sc)
 instance of Spark}
 
 \item{spark_home}{Spark home directory (defaults to SPARK_HOME environment variable)}
+
+\item{spark_version}{Spark version, if not specified, version taken from SPARK_HOME}
+
+\item{hadoop_version}{Hadoop version, if not specified, version taken from SPARK_HOME}
 
 \item{app_name}{Application name to be used while running in the Spark cluster}
 


### PR DESCRIPTION
We found a case (see https://github.com/rstudio/sparkapi/issues/10) where the Spark provider rips out all the version information from their distribution. We spent some time looking for file versions but EMR decided to remove all references.

For cases like this one, this PR proposes a couple things:
- When the `RELEASE` file is not found or is empty (this case), we also try to read the spark version from SPARK_HOME_VERSION which a user administrator could set for their users for this to work smoothly
- Allow the users to specify the target version using `spark_connect(version)` that we will use when connecting to the cluster

While there might, maybe, better ways to detect a version from a SPARK_HOME. I believe we still would need workarounds for the cases that we don't catch. For instance, someone might be testing against Spark 3.0.0 in a development branch but they might want to test against 2.0.0 binaries jars, etc.